### PR TITLE
Replace deprecated GH Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        uses: crazy-max/ghaction-import-gpg@v5.0.0
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.GPG_PASSWORD }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSWORD }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
As said in this thread
(https://github.com/hashicorp/ghaction-import-gpg/issues/11#issuecomment-1185107410),
upstream GH Action for GPG is now more suitable