### PR TITLE
Make error more readable

### DIFF
--- a/pkg/drivers/outscale/keypair.go
+++ b/pkg/drivers/outscale/keypair.go
@@ -65,11 +65,7 @@ func createKeyPair(d *OscDriver) error {
 	)
 
 	if err != nil {
-		log.Error("Error while submitting the Keypair creation request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the Keypair creation request: %s", getErrorInfo(err, httpRes))
 	}
 
 	if !response.HasKeypair() {
@@ -106,11 +102,7 @@ func deleteKeyPair(d *OscDriver, keypairName string) error {
 	)
 
 	if err != nil {
-		log.Error("Error while submitting the Keypair deletetion request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the Keypair deletetion request:  %s", getErrorInfo(err, httpRes))
 	}
 
 	return nil

--- a/pkg/drivers/outscale/outscale.go
+++ b/pkg/drivers/outscale/outscale.go
@@ -175,12 +175,8 @@ func (d *OscDriver) Create() error {
 	)
 
 	if err != nil {
-		log.Error("Error while submitting the Vm creation request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
 		cleanUp(d)
-		return err
+		return fmt.Errorf("Error while submitting the Vm creation request: %s", getErrorInfo(err, httpRes))
 	}
 
 	if !createVmResponse.HasVms() || len(createVmResponse.GetVms()) != 1 {
@@ -217,12 +213,8 @@ func (d *OscDriver) Create() error {
 		defaultThrottlingRetryOption...,
 	)
 	if err != nil {
-		fmt.Printf("Error while submitting the Vm creation request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
 		cleanUp(d)
-		return err
+		return fmt.Errorf("Error while submitting the Vm read request: %s", getErrorInfo(err, httpRes))
 	}
 
 	if !response.HasVms() {
@@ -391,11 +383,7 @@ func (d *OscDriver) GetState() (state.State, error) {
 	)
 
 	if err != nil {
-		fmt.Printf("Error while submitting the Vm creation request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return state.None, err
+		return state.None, fmt.Errorf("Error while submitting the Vm creation request: %s", getErrorInfo(err, httpRes))
 	}
 
 	if !readVmResponse.HasVms() {
@@ -436,11 +424,7 @@ func (d *OscDriver) PreCreateCheck() error {
 	)
 
 	if err != nil {
-		fmt.Printf("Error while submitting the ReadAccount request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the ReadAccount request: %s", getErrorInfo(err, httpRes))
 	}
 
 	// Check the SG
@@ -486,11 +470,7 @@ func (d *OscDriver) Remove() error {
 		)
 
 		if err != nil {
-			fmt.Printf("Error while submitting the DeleteVm request: ")
-			if httpRes != nil {
-				fmt.Printf(httpRes.Status)
-			}
-			return err
+			return fmt.Errorf("Error while submitting the DeleteVm request: %s", getErrorInfo(err, httpRes))
 		}
 
 		if err := d.waitForState(d.VmId, "terminated"); err != nil {
@@ -540,11 +520,7 @@ func (d *OscDriver) Restart() error {
 	)
 
 	if err != nil {
-		fmt.Printf("Error while submitting the RebootVm request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the RebootVm request: %s", getErrorInfo(err, httpRes))
 	}
 
 	if err := d.waitForState(d.VmId, "running"); err != nil {
@@ -635,11 +611,7 @@ func (d *OscDriver) Start() error {
 	)
 
 	if err != nil {
-		fmt.Printf("Error while submitting the StartVm request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the StartVm request: %s", getErrorInfo(err, httpRes))
 	}
 
 	if err := d.waitForState(d.VmId, "running"); err != nil {
@@ -674,11 +646,7 @@ func (d *OscDriver) innerStop(force bool) error {
 	)
 
 	if err != nil {
-		fmt.Printf("Error while submitting the StopVm request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the StopVm request: %s", getErrorInfo(err, httpRes))
 	}
 
 	if err := d.waitForState(d.VmId, "stopped"); err != nil {

--- a/pkg/drivers/outscale/public_ip.go
+++ b/pkg/drivers/outscale/public_ip.go
@@ -33,11 +33,7 @@ func createPublicIp(d *OscDriver) error {
 	)
 
 	if err != nil {
-		log.Error("Error while submitting the Public IP creation request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the Public IP creation request: %s", getErrorInfo(err, httpRes))
 	}
 
 	if !response.HasPublicIp() {
@@ -76,11 +72,7 @@ func linkPublicIp(d *OscDriver) error {
 	)
 
 	if err != nil {
-		log.Error("Error while submitting the Public IP link request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the Public IP link request: %s", getErrorInfo(err, httpRes))
 	}
 
 	if !response.HasLinkPublicIpId() {
@@ -123,11 +115,7 @@ func deletePublicIp(d *OscDriver, resourceId string) error {
 	)
 
 	if err != nil {
-		log.Error("Error while submitting the Public IP link deletion request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the Public IP link deletion request: %s", getErrorInfo(err, httpRes))
 	}
 
 	return nil

--- a/pkg/drivers/outscale/security_group.go
+++ b/pkg/drivers/outscale/security_group.go
@@ -42,11 +42,7 @@ func addSecurityGroupRule(d *OscDriver, sgId string, request *osc.CreateSecurity
 	)
 
 	if err != nil {
-		log.Error("Error while submitting the Security Group Rule creation request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the Security Group Rule creation request: %s", getErrorInfo(err, httpRes))
 	}
 
 	if !response.HasSecurityGroup() {
@@ -95,11 +91,7 @@ func createDefaultSecurityGroup(d *OscDriver) error {
 	)
 
 	if err != nil {
-		log.Error("Error while submitting the Security Group creation request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the Security Group creation request: %s", getErrorInfo(err, httpRes))
 	}
 
 	if !response.HasSecurityGroup() {
@@ -226,11 +218,7 @@ func deleteSecurityGroup(d *OscDriver, resourceId string) error {
 	)
 
 	if err != nil {
-		log.Error("Error while submitting the Security Group deletion request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the Security Group deletion request: %s", getErrorInfo(err, httpRes))
 	}
 
 	return nil
@@ -263,11 +251,7 @@ func isSecurityGroupExist(d *OscDriver, sgId string) (bool, error) {
 	)
 
 	if err != nil {
-		log.Error("Error while submitting the Security Group Rule read request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return false, err
+		return false, fmt.Errorf("Error while submitting the Security Group Rule read request: %s", getErrorInfo(err, httpRes))
 	}
 
 	return response.HasSecurityGroups() && (len(response.GetSecurityGroups()) == 1), nil

--- a/pkg/drivers/outscale/tag.go
+++ b/pkg/drivers/outscale/tag.go
@@ -42,11 +42,7 @@ func addTag(d *OscDriver, resourceId string, key string, value string) error {
 	)
 
 	if err != nil {
-		log.Error("Error while submitting the CreateTag request: ")
-		if httpRes != nil {
-			fmt.Printf(httpRes.Status)
-		}
-		return err
+		return fmt.Errorf("Error while submitting the CreateTag request: %s", getErrorInfo(err, httpRes))
 	}
 
 	return nil


### PR DESCRIPTION
Instead of printing the Status of the response HTTP. We print when it is possible the details of the API Error.

It will look like that:
- API Error
```
Error while unlinking route table rtb-X (links rtbassoc-X): 409 Conflict 4045 InvalidParameterValue
```
- Non API Error
```
Error while deleting security groups: 409 Conflict
```
